### PR TITLE
i18n: Add and improve full language support for UI, system messages, …

### DIFF
--- a/src/js/nf-api.js
+++ b/src/js/nf-api.js
@@ -33,7 +33,7 @@ async function nfAuthenticateUser(username, password) {
         
         // Check if both fields are filled
         if (!cleanUsername || !cleanPassword) {
-            const errorMessage = window.NF_CONFIG?.system?.labels?.loginErrors?.missingCredentials || 'Username and password are required';
+            const errorMessage = nfGetMessage('missingCredentials');
             if (typeof NFError !== 'undefined') {
                 throw new NFError(errorMessage, 'MISSING_CREDENTIALS');
             } else {
@@ -77,7 +77,7 @@ async function nfAuthenticateUser(username, password) {
                 if (nf._loginAttempts >= maxAttempts) {
                     // Lock account after too many attempts
                     nf._isAccountLocked = true;
-                    const lockoutMessage = window.NF_CONFIG?.ui?.login?.lockoutMessage;
+                    const lockoutMessage = nfGetMessage('lockoutMessage');
                     const errorMessage = lockoutMessage;
                     if (typeof NFError !== 'undefined') {
                         throw new NFError(errorMessage, 'ACCOUNT_LOCKED');
@@ -88,8 +88,8 @@ async function nfAuthenticateUser(username, password) {
                 
                 // 401 = Unauthorized - invalid credentials
                 // Simplified: no remaining attempts, just a generic warning
-                const errorMessage = 'Invalid credentials';
-                const warningMessage = window.NF_CONFIG?.ui?.login?.attemptsWarning;
+                const errorMessage = nfGetMessage('invalidCredentials');
+                const warningMessage = nfGetMessage('attemptsWarning');
                 if (typeof NFError !== 'undefined') {
                     const error = new NFError(errorMessage, 'INVALID_CREDENTIALS');
                     error.attemptsWarning = warningMessage;
@@ -101,7 +101,7 @@ async function nfAuthenticateUser(username, password) {
                 }
             }
             // Other HTTP errors (500, 503, etc.)
-            const errorMessage = `Authentication failed (${response.status})`;
+            const errorMessage = nfGetMessage('authFailed', undefined, { status: response.status });
             if (typeof NFError !== 'undefined') {
                 throw new NFError(errorMessage, 'AUTH_FAILED');
             } else {

--- a/src/js/nf-config.js
+++ b/src/js/nf-config.js
@@ -5,6 +5,7 @@
 // This file contains all important configuration settings for the entire
 // ticket frontend. API URLs, UI behavior, security policies
 // and debug options are managed centrally here and can be easily adjusted.
+// You can change the language at the bottom of this file.
 
 // ===============================
 // MAIN CONFIGURATION OBJECT
@@ -165,6 +166,9 @@ const NF_CONFIG = {
                 cancelReply: 'Cancel',
                 closeTicket: 'Mark ticket as resolved'
             },
+            ticketDetailCreated: 'Created:',
+            ticketDetailNumber: 'Ticket No.',
+            ticketDetailLastUpdated: 'Last updated:',
             // Gallery
             galleryAlt: 'Attachment',
             // Status mapping
@@ -246,6 +250,9 @@ const NF_CONFIG = {
                 cancelReply: 'Abbrechen',
                 closeTicket: 'Ticket als gelöst markieren'
             },
+            ticketDetailCreated: 'Erstellt am:',
+            ticketDetailNumber: 'Ticket Nr.',
+            ticketDetailLastUpdated: 'Zuletzt aktualisiert:',
             // Gallery (Galerie)
             galleryAlt: 'Anhang',
             // Status mapping (Status-Zuordnung)
@@ -305,7 +312,7 @@ const NF_CONFIG = {
         login_de: {
             maxAttempts: 3,
             lockoutMessage: 'Konto gesperrt. Bitte kontaktieren Sie den Support.',
-            credentialsHint: 'Verwenden Sie Ihre Windows-Anmeldedaten zur Anmeldung',
+            credentialsHint: 'Verwende deine Windows-Anmeldedaten zur Anmeldung',
             attemptsWarning: 'Fehler! Sind Benutzername/Passwort korrekt?'
         },
         // Mapping of Zammad status IDs to English labels
@@ -434,6 +441,31 @@ const NF_CONFIG = {
         ticketListLoadError: 'Fehler beim Laden der Tickets: ',
         ticketListFilterError: 'Fehler beim Filtern der Tickets: ',
         ticketListStatusSpanMissing: 'statusSpan nicht in Ticket-Zeilen-Vorlage gefunden'
+    },
+    // ===============================
+    // SYSTEM/USER MESSAGES (for notifications, status, etc.)
+    // ===============================
+    messages: {
+        ticketCreated: 'Ticket was created successfully!',
+        missingFields: 'Please fill in all required fields.',
+        fileValidationFailed: 'File validation failed.',
+        missingCredentials: 'Username and password are required',
+        lockoutMessage: 'Account locked. Please contact support.',
+        invalidCredentials: 'Invalid login credentials',
+        attemptsWarning: 'Error! Is the username/password correct?',
+        authFailed: 'Authentication failed ({status})',
+        // ...add more as needed...
+    },
+    messages_de: {
+        ticketCreated: 'Ticket wurde erfolgreich erstellt!',
+        missingFields: 'Bitte füllen Sie alle Pflichtfelder aus.',
+        fileValidationFailed: 'Datei-Überprüfung fehlgeschlagen.',
+        missingCredentials: 'Benutzername und Passwort sind erforderlich',
+        lockoutMessage: 'Konto gesperrt. Bitte kontaktieren Sie den Support.',
+        invalidCredentials: 'Ungültige Anmeldedaten',
+        attemptsWarning: 'Fehler! Sind Benutzername/Passwort korrekt?',
+        authFailed: 'Authentifizierung fehlgeschlagen ({status})',
+        // ...add more as needed...
     }
 };
 

--- a/src/js/nf-events.js
+++ b/src/js/nf-events.js
@@ -116,7 +116,7 @@ Object.assign(nf, {
             // REQUIRED FIELD VALIDATION
             // ===============================
             if (!subject || !body) {
-                throw new NFError('Please fill in all required fields.', 'MISSING_FIELDS');
+                throw new NFError(nfGetMessage('missingFields'), 'MISSING_FIELDS');
             }
             // ===============================
             // FILE VALIDATION
@@ -126,7 +126,7 @@ Object.assign(nf, {
                     try {
                         NFUtils.validateFile(file);
                     } catch (error) {
-                        throw new NFError(`File "${file.name}": ${error.message}`, 'FILE_VALIDATION_FAILED');
+                        throw new NFError(nfGetMessage('fileValidationFailed', undefined, { file: file.name, error: error.message }), 'FILE_VALIDATION_FAILED');
                     }
                 }
             }
@@ -135,7 +135,7 @@ Object.assign(nf, {
             // API CALL TO CREATE TICKET
             // ===============================
             await nfCreateTicket(subject, body, files);
-            nfShowStatus('Ticket was created successfully!', 'success', 'newticket');
+            nfShowStatus(nfGetMessage('ticketCreated'), 'success', 'newticket');
             // ===============================
             // CACHE INVALIDATION
             // ===============================

--- a/src/js/nf-helpers.js
+++ b/src/js/nf-helpers.js
@@ -105,8 +105,8 @@ const STATUS_ELEMENT_STYLES = `
  * @returns {string} The English status label
  */
 function nfStateLabel(stateId) {
-    const states = window.NF_CONFIG?.ui?.ticketStates;
-    return states[stateId] || window.NF_CONFIG?.system?.labels?.unknownStatus || 'Unknown';
+    const states = window.NF_CONFIG.getTicketStates(window.NF_CONFIG.currentLanguage);
+    return states[stateId] || window.NF_CONFIG.getLabels(window.NF_CONFIG.currentLanguage)?.unknownStatus || 'Unknown';
 }
 /**
  * Converts a file to a Base64 string for API uploads

--- a/src/js/nf-ticket-actions.js
+++ b/src/js/nf-ticket-actions.js
@@ -25,7 +25,7 @@ function nfSetupReplyInterface() {
         replyToggle = document.createElement('button');
         replyToggle.id = 'nf_ticketdetail_replytoggle';               // Unique ID for later reference
         replyToggle.className = 'nf-ticketdetail-replytoggle';        // CSS class for styling
-        replyToggle.textContent = NF_CONFIG.system.labels.ticketDetailActions.reply;
+        replyToggle.textContent = NF_CONFIG.getLabels(NF_CONFIG.currentLanguage).ticketDetailActions.reply;
         // Insert button before the reply box in the container
         nf.ticketDetailContainer.insertBefore(replyToggle, nf.ticketDetailReplyBox);
     }

--- a/src/js/nf-ticket-detail.js
+++ b/src/js/nf-ticket-detail.js
@@ -58,9 +58,12 @@ async function nfShowTicketDetailView(ticketId) {
             statusEl.className = 'nf-ticketdetail-status nf-ticketdetail-status--' + (ticket.state_id || 'default');
             statusEl.style.textAlign = 'center';
             statusEl.textContent = nfStateLabel(ticket.state_id);
-            dateEl.textContent = `Created: ${new Date(ticket.created_at).toLocaleString('en-US')}`;
-            ticketNumberEl.textContent = `Ticket No. ${ticket.number}`;
-            updatedDateEl.textContent = `Last updated: ${new Date(ticket.updated_at || ticket.created_at).toLocaleString('en-US')}`;
+            // Language-aware labels and date formatting
+            const labels = window.NF_CONFIG.getLabels(window.NF_CONFIG.currentLanguage);
+            const locale = window.NF_CONFIG.currentLanguage === 'de' ? 'de-DE' : 'en-US';
+            dateEl.textContent = `${labels.ticketDetailCreated || 'Created:'} ${new Date(ticket.created_at).toLocaleString(locale)}`;
+            ticketNumberEl.textContent = `${labels.ticketDetailNumber || 'Ticket No.'} ${ticket.number}`;
+            updatedDateEl.textContent = `${labels.ticketDetailLastUpdated || 'Last updated:'} ${new Date(ticket.updated_at || ticket.created_at).toLocaleString(locale)}`;
             processorEl.textContent = agentName;
         } else {
             // ===============================

--- a/src/js/nf-ticket-list.js
+++ b/src/js/nf-ticket-list.js
@@ -71,10 +71,10 @@ function nfInitializeFilters() {
     const yearFilter = document.getElementById('nf_filter_year');
     const reloadBtn = document.getElementById('nf_ticketlist_reload');
     // Set reload button label from config
-    if (reloadBtn && window.NF_CONFIG?.ui?.labels?.reloadButton) {
-        reloadBtn.textContent = window.NF_CONFIG.ui.labels.reloadButton;
-        reloadBtn.setAttribute('aria-label', window.NF_CONFIG.ui.labels.reloadButton);
-        reloadBtn.setAttribute('title', window.NF_CONFIG.ui.labels.reloadButton);
+    if (reloadBtn && window.NF_CONFIG.getLabels(window.NF_CONFIG.currentLanguage)?.reloadButton) {
+        reloadBtn.textContent = window.NF_CONFIG.getLabels(window.NF_CONFIG.currentLanguage).reloadButton;
+        reloadBtn.setAttribute('aria-label', window.NF_CONFIG.getLabels(window.NF_CONFIG.currentLanguage).reloadButton);
+        reloadBtn.setAttribute('title', window.NF_CONFIG.getLabels(window.NF_CONFIG.currentLanguage).reloadButton);
     }
     if (!statusFilter || !sortFilter || !yearFilter) return;
     // ===============================
@@ -213,7 +213,7 @@ function nfRenderTicketList(tickets) {
     // ===============================
     if (!tickets.length) {
         nfShow(nf.ticketListEmpty);  // Show "No tickets" message
-        nf.ticketListEmpty.textContent = NF_CONFIG.system.labels.ticketListEmpty;
+        nf.ticketListEmpty.textContent = NF_CONFIG.getLabels(NF_CONFIG.currentLanguage).ticketListEmpty;
         return;
     } else {
         nfHide(nf.ticketListEmpty);  // Hide "No tickets" message
@@ -256,12 +256,11 @@ function nfRenderTicketList(tickets) {
                     nfLogger.warn(NF_CONFIG.utilsMessages.ticketListStatusSpanMissing, { ticket: t });
                 }
             }
-            // Ticket title as clickable heading with ARIA
+            // Ticket title as plain text (no link)
             const subjectCell = tr.querySelector('.nf-ticketlist-cell--subject');
             if (subjectCell) {
-                const ariaLabelTemplate = NF_CONFIG.system.assets.aria.openTicket || 'Open ticket: {title}';
                 const ticketTitle = t.title || t.subject || '';
-                subjectCell.innerHTML = `<a href="#" class="nf-ticketlist-link" role="heading" aria-level="3" aria-label="${ariaLabelTemplate.replace('{title}', ticketTitle)}" tabindex="0">${ticketTitle}</a>`;
+                subjectCell.textContent = ticketTitle;
             }
         } else {
             // ===============================
@@ -272,7 +271,7 @@ function nfRenderTicketList(tickets) {
             tr.className = 'nf-ticketlist-row';
             tr.innerHTML = `
                 <td class="nf-ticketlist-cell nf-ticketlist-cell--id nf-center-text">${t.number || t.id || ''}</td>
-                <td class="nf-ticketlist-cell nf-ticketlist-cell--subject"><a href="#" class="nf-ticketlist-link" role="heading" aria-level="3" aria-label="${(NF_CONFIG.system.assets.aria.openTicket || 'Open ticket: {title}').replace('{title}', t.title || t.subject || '')}" tabindex="0">${t.title || t.subject || ''}</a></td>
+                <td class="nf-ticketlist-cell nf-ticketlist-cell--subject">${t.title || t.subject || ''}</td>
                 <td class="nf-ticketlist-cell nf-ticketlist-cell--created nf-center-text">${t.created_at ? new Date(t.created_at).toLocaleString('en-US') : ''}</td>
                 <td class="nf-ticketlist-cell nf-ticketlist-cell--status nf-center-text"><span class="nf-ticketlist-status nf-ticketlist-status--${t.state || t.state_id}">${nfStateLabel(t.state || t.state_id)}</span></td>
             `;

--- a/src/js/nf-ui-init.js
+++ b/src/js/nf-ui-init.js
@@ -48,8 +48,8 @@ const NF_UI_INIT = {
      * Initializes the main modal with configurable texts.
      */
     initMainModal: function() {
-        const labels = window.NF_CONFIG.system.labels;
-        const aria = window.NF_CONFIG.system.assets.aria;
+        const labels = window.NF_CONFIG.getLabels(window.NF_CONFIG.currentLanguage);
+        const aria = window.NF_CONFIG.getAriaLabels(window.NF_CONFIG.currentLanguage);
         
         // Modal title and subtitle
         const modalTitle = document.querySelector('.nf-modal-title');
@@ -93,7 +93,7 @@ const NF_UI_INIT = {
      * Initializes the knowledge portal card.
      */
     initKnowledgePortalCard: function() {
-        const labels = window.NF_CONFIG.system.labels;
+        const labels = window.NF_CONFIG.getLabels(window.NF_CONFIG.currentLanguage);
         const knowledgeCard = document.querySelector('.nf-card--knowledge');
         
         if (knowledgeCard && labels) {
@@ -119,7 +119,7 @@ const NF_UI_INIT = {
      * Initializes the ticket system card.
      */
     initTicketSystemCard: function() {
-        const labels = window.NF_CONFIG.system.labels;
+        const labels = window.NF_CONFIG.getLabels(window.NF_CONFIG.currentLanguage);
         const ticketCard = document.querySelector('.nf-card--tickets');
         
         if (ticketCard && labels) {
@@ -150,7 +150,7 @@ const NF_UI_INIT = {
      * Initializes the ticket list with configurable texts.
      */
     initTicketList: function() {
-        const labels = window.NF_CONFIG.system.labels;
+        const labels = window.NF_CONFIG.getLabels(window.NF_CONFIG.currentLanguage);
         
         // Filter options
         const statusFilter = document.getElementById('nf_filter_status');
@@ -205,7 +205,7 @@ const NF_UI_INIT = {
      * Initializes the ticket detail view.
      */
     initTicketDetail: function() {
-        const labels = window.NF_CONFIG.system.labels;
+        const labels = window.NF_CONFIG.getLabels(window.NF_CONFIG.currentLanguage);
         
         if (!labels.ticketDetailActions) return;
 
@@ -240,7 +240,7 @@ const NF_UI_INIT = {
      * Initializes the gallery.
      */
     initGallery: function() {
-        const aria = window.NF_CONFIG.system.assets.aria;
+        const aria = window.NF_CONFIG.getAriaLabels(window.NF_CONFIG.currentLanguage);
         const galleryOverlay = document.getElementById('nf_gallery_overlay');
         const galleryClose = document.getElementById('nf_gallery_close');
         const galleryPrev = document.getElementById('nf_gallery_prev');
@@ -255,7 +255,7 @@ const NF_UI_INIT = {
      * Initializes the login form.
      */
     initLogin: function() {
-        const labels = window.NF_CONFIG.system.labels;
+        const labels = window.NF_CONFIG.getLabels(window.NF_CONFIG.currentLanguage);
         
         if (!labels.loginTitle || !labels.loginLabels) return;
 
@@ -295,7 +295,7 @@ const NF_UI_INIT = {
      * Initializes the new ticket form.
      */
     initNewTicket: function() {
-        const labels = window.NF_CONFIG.system.labels;
+        const labels = window.NF_CONFIG.getLabels(window.NF_CONFIG.currentLanguage);
         
         if (!labels.newTicketTitle || !labels.newTicketLabels) return;
 

--- a/src/js/nf-ui.js
+++ b/src/js/nf-ui.js
@@ -177,7 +177,9 @@ function showLockoutMessage() {
 function showNormalLoginDisplay() {
     nfHide(nf.loginLockout);
     nf.loginSubmit.disabled = false;
-    const credentialsHint = window.NF_CONFIG?.ui?.login?.credentialsHint;
+    const credentialsHint = (window.NF_CONFIG?.currentLanguage === 'de')
+        ? window.NF_CONFIG?.ui?.login_de?.credentialsHint
+        : window.NF_CONFIG?.ui?.login?.credentialsHint;
     if (credentialsHint && nf.loginHint) {
         nf.loginHint.textContent = credentialsHint;
         nfShow(nf.loginHint);

--- a/src/js/nf-utils.js
+++ b/src/js/nf-utils.js
@@ -384,6 +384,18 @@ window.nfLogger = nfLogger;
 window.NFPerformance = NFPerformance;
 window.nfPerf = nfPerf;
 
+/**
+ * Returns a system/user message in the current language.
+ * Usage: nfGetMessage('ticketCreated')
+ */
+function nfGetMessage(key, language = window.NF_CONFIG?.currentLanguage || 'en') {
+    const config = window.NF_CONFIG;
+    if (language === 'de' && config.messages_de && config.messages_de[key]) return config.messages_de[key];
+    if (config.messages && config.messages[key]) return config.messages[key];
+    return key;
+}
+window.nfGetMessage = nfGetMessage;
+
 function isAllowedStyle(style, allowedStyles) {
     return allowedStyles.some(allowed => style.trim().startsWith(allowed));
 }


### PR DESCRIPTION
…and ticket details

- All UI labels and system/user messages now use language-aware functions
- Ticket detail view uses localized date/time and labels
- Added missing translations and improved German/English switching
- Ticket list and detail: no more hardcoded English text
- Credentials hint and all error/success messages are now localized
- Refactored message utility to nf-utils.js
- Various minor fixes for consistency